### PR TITLE
[FIXED] Build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ sudo apt-get install ruby-full build-essential zlib1g-dev
 sudo gem install bundler jekyll
 
 # This command will install all the dependencies specified in the Gemfile of your Jekyll project.
-bundle install
+sudo bundle install
+
+# Build the static site locally
+bundle exec jekyll build
 
 # Preview site at http://127.0.0.1:4000/
 bundle exec jekyll serve


### PR DESCRIPTION
Fixes

```

Bundler::PermissionError: There was an error while trying to write to
`/var/lib/gems/3.0.0/cache/public_suffix-4.0.7.gem`. It is likely that you need to grant write permissions
for that path.
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:107:in `rescue in
filesystem_access'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:104:in `filesystem_access'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:445:in `block in
download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:40:in `run'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:30:in `attempt'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:437:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:482:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:439:in `fetch_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:423:in `fetch_gem_if_possible'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:162:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:55:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:124:in `block in
worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing public_suffix (4.0.7), and Bundler cannot continue.

In Gemfile:
  jekyll-sitemap was resolved to 1.2.0, which depends on
    jekyll was resolved to 3.10.0, which depends on
      addressable was resolved to 2.8.7, which depends on
        public_suffix

Bundler::PermissionError: There was an error while trying to write to
`/var/lib/gems/3.0.0/cache/i18n-0.9.5.gem`. It is likely that you need to grant write permissions for that
path.
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:107:in `rescue in
filesystem_access'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:104:in `filesystem_access'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:445:in `block in
download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:40:in `run'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:30:in `attempt'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:437:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:482:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:439:in `fetch_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:423:in `fetch_gem_if_possible'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:162:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:55:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:124:in `block in
worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing i18n (0.9.5), and Bundler cannot continue.

In Gemfile:
  jekyll-sitemap was resolved to 1.2.0, which depends on
    jekyll was resolved to 3.10.0, which depends on
      i18n

Bundler::PermissionError: There was an error while trying to write to
`/var/lib/gems/3.0.0/cache/sass-listen-4.0.0.gem`. It is likely that you need to grant write permissions
for that path.
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:107:in `rescue in
filesystem_access'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:104:in `filesystem_access'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:445:in `block in
download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:40:in `run'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:30:in `attempt'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:437:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:482:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:439:in `fetch_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:423:in `fetch_gem_if_possible'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:162:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:55:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:124:in `block in
worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing sass-listen (4.0.0), and Bundler cannot continue.

In Gemfile:
  jekyll-sitemap was resolved to 1.2.0, which depends on
    jekyll was resolved to 3.10.0, which depends on
      jekyll-sass-converter was resolved to 1.5.2, which depends on
        sass was resolved to 3.7.4, which depends on
          sass-listen

Bundler::PermissionError: There was an error while trying to write to
`/var/lib/gems/3.0.0/cache/rouge-3.30.0.gem`. It is likely that you need to grant write permissions for
that path.
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:107:in `rescue in
filesystem_access'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:104:in `filesystem_access'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:445:in `block in
download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:40:in `run'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:30:in `attempt'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:437:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:482:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:439:in `fetch_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:423:in `fetch_gem_if_possible'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:162:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:55:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:124:in `block in
worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing rouge (3.30.0), and Bundler cannot continue.

In Gemfile:
  jekyll-sitemap was resolved to 1.2.0, which depends on
    jekyll was resolved to 3.10.0, which depends on
      rouge

Bundler::PermissionError: There was an error while trying to write to
`/var/lib/gems/3.0.0/cache/jekyll-paginate-1.1.0.gem`. It is likely that you need to grant write
permissions for that path.
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:107:in `rescue in
filesystem_access'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/shared_helpers.rb:104:in `filesystem_access'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:445:in `block in
download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:40:in `run'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/retry.rb:30:in `attempt'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/rubygems_integration.rb:437:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:482:in `download_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:439:in `fetch_gem'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:423:in `fetch_gem_if_possible'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/source/rubygems.rb:162:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:55:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/gem_installer.rb:17:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:133:in `do_install'
/var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/installer/parallel_installer.rb:124:in `block in
worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.5.21/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing jekyll-paginate (1.1.0), and Bundler cannot continue.

In Gemfile:
  jekyll-paginate
```