### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Check out the project and run following command to test the site:
 ```sh
 # If 'bundle' is not installed on macOS, run the following
 sudo gem install bundler -v 2.4.22
+sudo gem install rouge -v 3.30.0
 sudo gem install jekyll
 
 # Preview site at http://127.0.0.1:4000/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Check out the project and run following command to test the site:
 
 ```sh
 # If 'bundle' is not installed on macOS, run the following
+# ruby -v = ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin24]
+# gem -v = 3.0.3.1
 sudo gem install bundler -v 2.4.22
 sudo gem install rouge -v 3.30.0
 sudo gem install jekyll

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Check out the project and run following command to test the site:
 
 ```sh
 # If 'bundle' is not installed on macOS, run the following
-gem install bundler jekyll
+sudo gem install bundler -v 2.4.22
+sudo gem install jekyll
 
 # Preview site at http://127.0.0.1:4000/
 bundle exec jekyll serve


### PR DESCRIPTION
Changed because of following error

```
➜  vision.hossainkhan.com git:(master) sudo gem install bundler jekyll

Fetching bundler-2.5.23.gem
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.6.10.210.
```