### PR TITLE
[FIXED] Apparently `$default-branch` does not exist

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -2,9 +2,9 @@ name: Jekyll site CI
 # https://github.com/actions/starter-workflows/blob/main/ci/jekyll.yml
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ main ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration for the Jekyll site CI. The most important change is updating the branch references from a variable to a specific branch name.

Changes to GitHub Actions workflow:

* [`.github/workflows/jekyll.yml`](diffhunk://#diff-60ac246cc02819dea1007076ba57241caa7c7d1e8232a5179124d4e63bb366f8L5-R7): Updated the branch references from `$default-branch` to `main` for both `push` and `pull_request` events.

GitHub workflows do not have a `$default-branch` variable directly. However, you can use the `${{ github.ref }}` context variable to get the reference for the branch or tag that triggered the workflow, which often serves a similar purpose. For more details, refer to the [GitHub Actions documentation](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context).