### PR TITLE
Fix: Correct typos and grammatical errors in posts and projects

### DIFF
--- a/_posts/2014-11-17-nothing-ness-near-the-beach.md
+++ b/_posts/2014-11-17-nothing-ness-near-the-beach.md
@@ -7,8 +7,8 @@ featured_image: '/images/2014-11/IMG_20141117_163103-sunset-near-golden-gate-bri
 ![](/images/2014-11/IMG_20141117_163103-sunset-near-golden-gate-bridge-1600x1000.jpg)
 
 ## A day to relax! 🍹
-California is one of my favorite destinations. The key reason I love this place is that it has combination of all the
-things I like, such as Mountains 🗻, Beach 🏖, Clear Sky ☀️, Nice Drive 🚗. 
+California is one of my favorite destinations. The key reason I love this place is that it has a combination of all the
+things I like, such as mountains 🗻, beaches 🏖, clear skies ☀️, and nice drives 🚗.
 
 
 💕 California.

--- a/_posts/2017-03-27-a-journey-of-a-foodie.md
+++ b/_posts/2017-03-27-a-journey-of-a-foodie.md
@@ -7,14 +7,14 @@ featured_image: '/images/2017-03/IMG_20170330_1892-sashimi-at-hiroshima-1600x100
 ![](/images/2017-03/IMG_20170330_1892-sashimi-at-hiroshima-1600x1000.jpg)
 
 ## I live to eat!
-Besides taking random shots, I love trying our different cuisine. In other words you can call me "foodie".
-I may forget many things, but I never* forget to take picture of my food.
+Besides taking random shots, I love trying out different cuisines. In other words, you can call me a "foodie".
+I may forget many things, but I never* forget to take a picture of my food.
 
-Here are some of the snapshots that I can find.
+Here are some of the snapshots that I could find.
 
 
-You can also [follow](https://www.google.com/maps/contrib/107431117693660399546/reviews/@36.6377836,-88.8707038,5z?hl=en-CA) me on Google Maps, I am `Level 7` local guide. 
+You can also [follow](https://www.google.com/maps/contrib/107431117693660399546/reviews/@36.6377836,-88.8707038,5z?hl=en-CA) me on Google Maps; I am a `Level 7` Local Guide.
 
 > “Food is life, life is food.”
 
-<small>* _Clarification, when I am hungry and food is too good, I forget to take snap, but I don't forget to take picture of empty plate after I am done._ 😂</small> 
+<small>* _Clarification: when I am hungry and the food is too good, I forget to take a snap, but I don't forget to take a picture of the empty plate after I am done._ 😂</small>

--- a/_posts/2017-12-28-driving-through-cloud.md
+++ b/_posts/2017-12-28-driving-through-cloud.md
@@ -7,11 +7,11 @@ featured_image: '/images/2017-12/DSC_20171228_04009-jamaica-mountain-cloud-1700x
 ![](/images/2017-12/DSC_20171228_04009-jamaica-mountain-cloud-1700x1100.jpg)
 
 ## 🚗 Driving through clouds
-We took a road trip through Blue Mountains National Park, Jamaica. It was an amazing view from the top of the mountain.
+We took a road trip through Blue Mountains National Park in Jamaica. It was an amazing view from the top of the mountain.
 We got to drive through clouds ⛅️, which was an amazing experience.
 
 > “Life is a journey, get the best out of it :-)”
 
-Here is a time-lapse I took while I was driving through Blue Mountain.
+Here is a time-lapse I took while I was driving through the Blue Mountains.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/hwpKiM99_GY?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/_posts/2018-06-07-just-another-day-to-experiment.md
+++ b/_posts/2018-06-07-just-another-day-to-experiment.md
@@ -8,9 +8,9 @@ featured_image: '/images/about-hk/DSC_20180607_04859-hk-on-the-balcony-1200x800.
 
 ## Getting ready for shot...
 
-Just another day at my home. Getting ready for Hamilton falls day trip. Excited to be outdoors and have some fun.
-Every day brings opportunity to capture moments. Personally, I don't care about the quality of the picture, is long
-as tells a story, it's worth taking. 
+Just another day at my home, getting ready for a Hamilton Falls day trip. Excited to be outdoors and have some fun.
+Every day brings opportunity to capture moments. Personally, I don't care about the quality of the picture; as long
+as it tells a story, it's worth taking.
 
 > “Enjoy every moment of life! Do what you love and love what you do!”
 

--- a/_posts/2018-08-29-mind-is-like-sky.md
+++ b/_posts/2018-08-29-mind-is-like-sky.md
@@ -7,8 +7,8 @@ featured_image: '/images/2018-08/IMG_20180829_8953-sky-view-from-balcony-1600x11
 ![Exposure Time: 1/250, FNumber: 10, Focal Length: 24](/images/2018-08/IMG_20180829_8953-sky-view-from-balcony-1600x1100.jpeg)
 
 ## Mind is like sky
-Every day gives us unique opportunity to view our surrounding differently. The sky constantly sifts and gives us millions combination of views.
-I get excited with the views it creates, specially during sunset. Because, every second it shows different color.
+Every day gives us a unique opportunity to view our surroundings differently. The sky constantly shifts and gives us millions of combinations of views.
+I get excited by the views it creates, especially during sunset. Because every second it shows a different color.
 
 This is a random view from my balcony before the sunset.
 

--- a/_posts/2018-09-29-hiking-for-the-fall-color.md
+++ b/_posts/2018-09-29-hiking-for-the-fall-color.md
@@ -7,10 +7,10 @@ featured_image: '/images/2018-09/IMG_20180929_1649-vista-trail-observatory-fall-
 ![Exposure Time: 1/60, FNumber: 20, Focal Length: 24mm, ISO: 200](/images/2018-09/IMG_20180929_1649-vista-trail-observatory-fall-color-begins-1500x1000.jpeg)
 
 ## Hiking on vista trail
-Its almost October, a perfect time to capture the natural transition. We went to Rouge Park's vista trail.
+It's almost October, a perfect time to capture the natural transition. We went to Rouge Park's Vista Trail.
 Fortunately, we did get some fall colors on the trees 🌳. The day was perfect for hiking too.
 
-I will surely come back again when all the trees are on fire!! 🔥
+I will surely come back again when all the trees are on fire! 🔥
 
 
 <div class="gallery" data-columns="2">

--- a/_posts/2018-09-29-photoshoot-on-rouge-trail.md
+++ b/_posts/2018-09-29-photoshoot-on-rouge-trail.md
@@ -8,7 +8,7 @@ featured_image: '/images/front-page/IMG_20180929_1617-ovi-portrait-shot-rouge-pa
 ![Exposure Time: 1/4000, FNumber: 1.8, Focal Length: 50](/images/front-page/IMG_20180929_1617-ovi-portrait-shot-rouge-park-1600x1100.jpg)
 
 ## 📸 Making people smile ^_^
-This is an engagement shootout at end of September when the leaves just started to show fall colors 🍁🍁🍁.
+This is an engagement shootout at the end of September when the leaves just started to show fall colors 🍁🍁🍁.
 
 
 <div class="gallery" data-columns="3">

--- a/_posts/2018-10-07-relaxation-on-the-beach.md
+++ b/_posts/2018-10-07-relaxation-on-the-beach.md
@@ -7,9 +7,9 @@ featured_image: '/images/2018-10/IMG_20181007_180855-relax-on-the-beach-1500x100
 ![Aperture Value: 1.7, Exposure Time: 1/731, FNumber: 1.8, Focal Length: 4.459, Focal Length In 35mm Film: 27, ISO Speed Ratings: 51](/images/2018-10/IMG_20181007_180855-relax-on-the-beach-1500x1000.jpg)
 
 ## 🌊 Beach time 🏖
-Sea beach is one of my favorite place to be on earth.
-There is something special about the waves! The sound, makes me calm and relaxing.
+The sea beach is one of my favorite places to be on Earth.
+There is something special about the waves! Their sound makes me calm and relaxed.
 
-Now, go out there and find your "beach time", it could be spending time with family, playing soccer or anything you love to do and make your mind relaxed.
+Now, go out there and find your "beach time"; it could be spending time with family, playing soccer, or anything you love to do that makes your mind relaxed.
 
 > “Sometimes the most productive thing you can do is relax.” - Mark Black 

--- a/_posts/2018-10-27-food-experiments.md
+++ b/_posts/2018-10-27-food-experiments.md
@@ -7,7 +7,7 @@ featured_image: '/images/2018-10/IMG_3007-harder-than-it-seems-ANIMATION-small.g
 ![Aperture Value: 5.375, Exposure Time: 1/200, FNumber: 6.3, Focal Length: 50](/images/2018-10/IMG_3010-harder-than-it-seems-1500x1000.jpg)
 
 ## 🌬️ In motion...
-I was trying to capture some of the wild flower petals in motion. It did seem cool in-front of the eye, but capturing it was not that easy.
-It's most likely I did not have a good contrasting background and the focus plane was not right. 
+I was trying to capture some of the wild flower petals in motion. It did seem cool in front of the eye, but capturing it was not that easy.
+It's most likely that I did not have a good contrasting background and the focal plane was not right.
 
-Next time I should spend more time trying to get the perfect shot! Never give up!! (Self reminder 😊) 
+Next time I should spend more time trying to get the perfect shot! Never give up! (Self-reminder 😊)

--- a/_posts/2018-10-31-harder-than-it-seems.md
+++ b/_posts/2018-10-31-harder-than-it-seems.md
@@ -7,9 +7,8 @@ featured_image: '/images/2018-10/IMG_20181027_155457-food-experiments-1500x900.j
 ![Aperture Value: 1.7, Exposure Time: 1/60, FNumber: 1.8, Focal Length: 4.459, Focal Length In 35mm Film: 27, ISO Speed Ratings: 400](/images/2018-10/IMG_20181027_155457-food-experiments-1500x900.jpg)
 
 ## Live Green 🥒🍅🥬🥕
-Today we made some green healthy food to treat ourselves. It turned out to be an amazing dish.
+Today we made some green, healthy food to treat ourselves. It turned out to be an amazing dish.
 
-If you are interested, we got this item from the "[Beauty Food](https://www.amazon.ca/Beauty-Food-recipes-health-beauty/dp/1784725250/)"
+If you are interested, we got this recipe from the book "[Beauty Food](https://www.amazon.ca/Beauty-Food-recipes-health-beauty/dp/1784725250/)"
 
 ![](https://images-na.ssl-images-amazon.com/images/I/31lPogW51eL.jpg)
-

--- a/_posts/2019-07-14-playing-with-water.md
+++ b/_posts/2019-07-14-playing-with-water.md
@@ -6,10 +6,9 @@ featured_image: '/images/2019-07/DSC05689-playing-with-the-water-1600x1000.jpg'
 
 ![Aperture Value: 5.6, Exposure Time: 1/200, FNumber: 5.6, Focal Length: 4, Focal Length In 35mm Film: 27, ISO Speed Ratings: 400](/images/2019-07/DSC05689-playing-with-the-water-1600x1000.jpg)
 
-## A short visit in Tobermory
-Recently I visited Tobermory and Flowerpot island after almost a decade. I totally forgot how beautiful it was.
+## A short visit to Tobermory
+Recently, I visited Tobermory and Flowerpot Island after almost a decade. I totally forgot how beautiful it was.
 The water was insanely clear! Even though it was damn cold, I did get in the water to experience this unique beauty.
 
 
 ![](/images/2019-07/MVIMG_20190713_180424-playing-with-the-water2-1000x1400.jpg)
-

--- a/_posts/2020-01-04-frozen-morning.md
+++ b/_posts/2020-01-04-frozen-morning.md
@@ -7,10 +7,10 @@ featured_image: '/images/2020-01/IMG_7135-frozen-morning-1600x1100.jpg'
 ![Aperture Value: 4.5, Exposure Time: 1/200, FNumber: 4.5, Focal Length: 4, Focal Length: 100mm, ISO Speed Ratings: 100](/images/2020-01/IMG_7135-frozen-morning-1600x1100.jpg)
 
 ## A blissful surprise in the morning
-When I got up on Saturday morning, I looked outside and I was stunned by the view of thin layer
-of ice sitting on everything you can see.
+When I got up on Saturday morning, I looked outside and was stunned by the view of a thin layer
+of ice sitting on everything you could see.
 
-This is not a typical snow day, it's just right amount of snow that makes things look beautiful.
-I knew this won't last long, so, I grabbed my camera and started snapping the moment.
+This was not a typical snow day; it was just the right amount of snow that made things look beautiful.
+I knew this wouldn't last long, so I grabbed my camera and started snapping the moment.
 
 > “Imagination is the air of mind.” - Philip James Bailey

--- a/_posts/2020-01-23-exploring-small-town.md
+++ b/_posts/2020-01-23-exploring-small-town.md
@@ -8,9 +8,9 @@ featured_image: '/images/2020-01/IMG_20200121_163328-PANO-01-cusco-hdr-1600x1100
 
 ## Exploring old city - Cusco
 Cusco is a city in Peru where you stop by to visit Machu Picchu. Not knowing much about it made things even more exciting for me.
-I have explored parts of this old city by walking around. This is where I also had best Ceviche in Peru.
+I have explored parts of this old city by walking around. This is where I also had the best Ceviche in Peru.
 
-You can easily spend weeks if not months exploring the city and nearby attractions.
+You could easily spend weeks, if not months, exploring the city and nearby attractions.
 
 > “Live, Laugh & Love.”
 

--- a/_posts/2020-09-27-walking-through-fire.md
+++ b/_posts/2020-09-27-walking-through-fire.md
@@ -7,6 +7,6 @@ featured_image: '/images/2020-09/IMG_0820-HDR-arrowhead-park-beach-2000x1200.jpe
 ![](/images/2020-09/IMG_0820-HDR-arrowhead-park-beach-2000x1200.jpeg)
 
 ## Fall of 2020
-What a year we had, however, the nature kept healing itself while we stayed inside.
-During the fall it was great to be outside and share some of our feelings with nature.
+What a year we had; however, nature kept healing itself while we stayed inside.
+During the fall, it was great to be outside and share some of our feelings with nature.
 > “Leave the road, take the trails.” - Pythagoras

--- a/_posts/2020-10-25-bridge-over-niagara.md
+++ b/_posts/2020-10-25-bridge-over-niagara.md
@@ -7,9 +7,9 @@ featured_image: '/images/2020-10/IMG_2075-rainbow-bridge.jpg'
 ![](/images/2020-10/IMG_2075-rainbow-bridge.jpg)
 
 ## Bridge that connects! 🇨🇦🇺🇸
-One of the most popular bridge that connects us Canadians with the USA. A must-visit place at [any time](https://www.google.com/maps/contrib/107431117693660399546/place/ChIJ6XotQQdD04kRW-OcaB4dvik/@41.8695956,-88.7620744,6z/data=!4m6!1m5!8m4!1e1!2s107431117693660399546!3m1!1e1).
+One of the most popular bridges that connect us Canadians with the USA. It's a must-visit place at [any time](https://www.google.com/maps/contrib/107431117693660399546/place/ChIJ6XotQQdD04kRW-OcaB4dvik/@41.8695956,-88.7620744,6z/data=!4m6!1m5!8m4!1e1!2s107431117693660399546!3m1!1e1).
 
-Every time I go there I find different places that I haven't explored except the falls itself.
+Every time I go there, I find different places that I haven't explored, besides the falls themselves.
 
 
 <div class="gallery" data-columns="2">

--- a/_posts/2022-06-02-floating-on-the-air.md
+++ b/_posts/2022-06-02-floating-on-the-air.md
@@ -7,6 +7,6 @@ featured_image: '/images/2022-06/PXL_20220602_202418412.PANO.jpg'
 ![](/images/2022-06/PXL_20220602_202418412.PANO.jpg)
 
 ## Floating on the air 🌬☁️
-After almost 2 years of lockdown, we are (kinda) free now. Enjoy the air, the water the mother earth as much as you want. 🌎
+After almost two years of lockdown, we are (kinda) free now. Enjoy the air, the water, and Mother Earth as much as you want. 🌎
 
 > “The sky is the ultimate art gallery just above us.” – Ralph Waldo Emerson

--- a/_posts/2022-07-16-breath-of-fresh-air.md
+++ b/_posts/2022-07-16-breath-of-fresh-air.md
@@ -6,5 +6,5 @@ featured_image: '/images/2022-07/PXL_20220716_101201079.PHOTOSPHERE-3000x1250.jp
 
 ![](/images/2022-07/PXL_20220716_101201079.PHOTOSPHERE-3000x1250.jpg)
 
-## Breath of fresh air 🧘‍♂️
+## A breath of fresh air 🧘‍♂️
 A snap from the hiking trail near the camping site. Super peaceful hike ❤️ 

--- a/_posts/2022-09-11-hiking-in-the-wild.md
+++ b/_posts/2022-09-11-hiking-in-the-wild.md
@@ -7,7 +7,7 @@ featured_image: '/images/2022-09/IMG_7432-hiking-in-the-wild-1800x1000.jpg'
 ![](/images/2022-09/IMG_7432-hiking-in-the-wild-1800x1000.jpg)
 
 ## Hiking in the wild 🌳
-Another hike around the cabin at the Arrowhead Prov Park. 
+Another hike around the cabin at Arrowhead Provincial Park.
 
 <div class="gallery" data-columns="2">
 	<img src="/images/2022-09/IMG_7397-1800x1200.jpg">

--- a/_posts/2023-04-23-busy-day.md
+++ b/_posts/2023-04-23-busy-day.md
@@ -7,7 +7,7 @@ featured_image: '/images/2023-04/IMG_9095-japan-street1-1800x1200.jpg'
 ![](/images/2023-04/IMG_9095-japan-street1.JPG)
 
 ## Busy day 🚶
-A busy day in Japan, people rushing to work, school, or just to get to the next place. I was just walking around and enjoying the view. 🚶
+A busy day in Japan: people rushing to work, school, or just to get to the next place. I was just walking around and enjoying the view. 🚶
 
 <div class="gallery" data-columns="3">
 	<img alt="Japan street photo" src="/images/2023-04/IMG_9041-japan-street3-1800x1200.jpg">

--- a/_posts/2023-10-21-take-a-pause.md
+++ b/_posts/2023-10-21-take-a-pause.md
@@ -7,9 +7,9 @@ featured_image: '/images/2023-10/PXL_20231022_010649980-dinner-by-nature-1200x16
 ![](/images/2023-10/PXL_20231022_010649980-dinner-by-nature.jpg)
 
 ## Take a pause...
-Sometimes it's okay to take a pause and enjoy you!
+Sometimes it's okay to take a pause and enjoy yourself!
 
-This was a quick break at highway-1, California. Outstanding food and the view. ☀️
+This was a quick break on Highway 1, California. The food and the view were outstanding. ☀️
 
 <div class="gallery" data-columns="2">
 	<img src="/images/2023-10/PXL_20231022_012742092-rustic-present.jpg">

--- a/_posts/2023-10-21-timeless-selfie.md
+++ b/_posts/2023-10-21-timeless-selfie.md
@@ -7,5 +7,5 @@ featured_image: '/images/2023-10/PXL_20231022_004856113-hk-sunset-1200x1600.jpg'
 ![](/images/2023-10/PXL_20231022_004856113-hk-sunset.jpg)
 
 ## Timeless Selfie 🤳
-Yes! There are some white spots, does that make me old?
-So be it! I will not let my looks stop me from being me! Will see you at the next site! ✌️
+Yes! There are some white spots; does that make me old?
+So be it! I will not let my looks stop me from being me! I will see you at the next site! ✌️

--- a/_posts/2024-02-03-frozen-land.md
+++ b/_posts/2024-02-03-frozen-land.md
@@ -7,4 +7,4 @@ featured_image: '/images/2024-02/PXL_20240203_182404199-PANO-frozen-park-2000x10
 ![](/images/2024-02/PXL_20240203_182404199-PANO-frozen-park.jpg)
 
 ## Frozen Land ❄️
-A panoramic view of the frozen park in the Yosemite Valley, California, USA.
+A panoramic view of a frozen park in Yosemite Valley, California, USA.

--- a/_posts/2024-04-23-love-is-everywhere.md
+++ b/_posts/2024-04-23-love-is-everywhere.md
@@ -8,10 +8,10 @@ featured_image: '/images/2024-04/PXL_20240423_091800501-EDIT-love-is-everywhere-
 
 ## Endless Love ❤️
 
-Love is everywhere. It's in the air, in the water, in the sky, in the earth, in the universe. 
+Love is everywhere. It's in the air, in the water, in the sky, in the Earth, in the universe.
 
 A popular symbol of love and commitment, love padlocks are often attached to bridges and other structures by couples as
 a way to show their everlasting love. The padlocks are typically engraved with the couples' names or initials, and the
-key is thrown away to symbolize the unbreakable bond between them.
+key is thrown away to symbolize their unbreakable bond.
 
 > "Love is the greatest refreshment in life." – Pablo Picasso

--- a/_posts/2024-04-26-embracing-the-giant.md
+++ b/_posts/2024-04-26-embracing-the-giant.md
@@ -8,6 +8,6 @@ featured_image: '/images/2024-04/PXL_20240426_060328125e-embracing-the-giant-120
 
 ## Embracing the Giant 🌳
 
-Giant Camphor Tree of Kamoh Shrine, Fukuoka, Japan. This tree is estimated to be over 1,000 years old and is a symbol of strength and endurance.
+The Giant Camphor Tree of Kamoh Shrine, Fukuoka, Japan. This tree is estimated to be over 1,000 years old and is a symbol of strength and endurance.
 
 > "Look deep into nature, and then you will understand everything better." – Albert Einstein

--- a/_projects/2016-04-25-grand-canyon.md
+++ b/_projects/2016-04-25-grand-canyon.md
@@ -8,7 +8,7 @@ featured_image: '/images/front-page/DSC_20160425_03953-grand-canyon-1600x1100.jp
 ![](/images/front-page/DSC_20160425_03953-grand-canyon-1600x1100.jpg)
 
 ## Grand View
-The wonder of the world - Grand Canyon 🏜.
+A wonder of the world - the Grand Canyon 🏜.
 
 
 <div class="gallery" data-columns="3">

--- a/_projects/2017-03-30-last-building-standing.md
+++ b/_projects/2017-03-30-last-building-standing.md
@@ -8,9 +8,9 @@ featured_image: '/images/front-page/IMG_20170330_1702-hiroshima-last-building-st
 ![](/images/front-page/IMG_20170330_1702-hiroshima-last-building-standing-1600x800.jpg)
 
 ## 💥 History made
-It was a completely different feeling to stand in-front of the building that stood after the Hiroshima atom bomb attack.
+It was a completely different feeling to stand in front of the building that remained standing after the Hiroshima atom bomb attack.
 
-I hope we have learned from history and this never happens again.
+I hope we have learned from history and that this never happens again.
 
 > “Wars are poor chisels for carving out peaceful tomorrows.” - Martin Luther King, Jr.
 

--- a/_projects/2017-04-02-japan-cherry-blossom.md
+++ b/_projects/2017-04-02-japan-cherry-blossom.md
@@ -8,7 +8,7 @@ featured_image: '/images/front-page/IMG_20170402_1213-japan-cherry-blossom-1700x
 ![](/images/2017-04/IMG_20170402_1212-japan-cherry-blossom-1200x1600.jpg)
 
 ## 🌸 Cherry blossom 
-Small park with amazing cherry trees waiting to bloom during sakura event at 🇯🇵.
+A small park with amazing cherry trees waiting to bloom during the sakura event in 🇯🇵.
 
 
 <div class="gallery" data-columns="4">

--- a/_projects/2017-28-28-jamaica-mountain-falls.md
+++ b/_projects/2017-28-28-jamaica-mountain-falls.md
@@ -8,7 +8,7 @@ featured_image: '/images/front-page/DSC_20171228_04001-jamaica-mountain-falls-16
 ![](/images/front-page/DSC_20171228_04001-jamaica-mountain-falls-1600x1100.jpg)
 
 ## Calm and quiet
-A majestic falls over the top of mountain route to Kingston.
+A majestic waterfall on a mountain route to Kingston.
 
 > "Waterfalls wouldn't sound so melodious if there were no rocks in their way." - Rishabh Gautam
 

--- a/_projects/2018-09-06-camp-stars.md
+++ b/_projects/2018-09-06-camp-stars.md
@@ -8,4 +8,4 @@ featured_image: '/images/front-page/IMG_20180906-1600x1100-camp-ahmek-stars.jpg'
 ![](/images/front-page/IMG_20180906-1600x1100-camp-ahmek-stars.jpg)
 
 ## Twinkle twinkle little stars 🌟
-A perfect night with clear sky at the Camp Ahmek site.
+A perfect night with a clear sky at the Camp Ahmek site.

--- a/_projects/2018-09-07-misty-morning.md
+++ b/_projects/2018-09-07-misty-morning.md
@@ -8,6 +8,6 @@ featured_image: '/images/front-page/IMG_20180907_073851-1600x1200-camp-ahmek-bri
 ![](/images/front-page/IMG_20180907_073851-1600x1200-camp-ahmek-bridge-bnw.jpg)
 
 ## Let's get lost...
-The morning was cold, but the water was warm creating a misty morning.
+The morning was cold, but the water was warm, creating a misty atmosphere.
 
 > “Let me tell you something my friend. Hope is a dangerous thing. Hope can drive a man insane.” - The Shawshank Redemption 

--- a/_projects/2018-10-21-fall-nature-walk.md
+++ b/_projects/2018-10-21-fall-nature-walk.md
@@ -8,8 +8,8 @@ featured_image: '/images/front-page/IMG_20181021_3476x-fall-nature-wild-flower-b
 ![Exposure Time: 1/4000, FNumber: 1.8, Focal Length: 50, ISO: 200](/images/front-page/IMG_20181021_3476x-fall-nature-wild-flower-blooming.jpeg)
 
 ## Beauty is in the eye of the beholder
-The nature is full of beauty, you just have to stop of focus on them.
-This shot is taken from the [Forks of the Credit](https://www.ontarioparks.com/park/forksofthecredit) Provincial Park during end of fall season.
+Nature is full of beauty; you just have to stop to focus on it.
+This shot was taken at the [Forks of the Credit](https://www.ontarioparks.com/park/forksofthecredit) Provincial Park towards the end of the fall season.
 
 Would love to go back to the park for more hiking.
 

--- a/_projects/2018-11-11-winter-is-coming.md
+++ b/_projects/2018-11-11-winter-is-coming.md
@@ -8,7 +8,7 @@ featured_image: '/images/front-page/IMG_20181111_3644-frozen-leaf-1600x1000.jpg'
 ![Exposure Time: 1/125, FNumber: 7.1, Focal Length: 100, ISO: 200](/images/front-page/IMG_20181111_3644-frozen-leaf-1600x1000.jpg)
 
 ## Frozen leaf 🍁
-Winter is coming, it's time trees to go into hibernation.
+Winter is coming; it's time for trees to go into hibernation.
 
 > “If Winter comes, can Spring be far behind?” - Percy Bysshe Shelley
 

--- a/_projects/2018-12-28-quiet-mosque-in-the-market.md
+++ b/_projects/2018-12-28-quiet-mosque-in-the-market.md
@@ -8,7 +8,6 @@ featured_image: '/images/front-page/IMG_20181228_165519-mosque-in-the-market-150
 ![Aperture Value: 1.7, Exposure Time: 1/130, FNumber: 1.8, Focal Length: 4.459, Focal Length In 35mm Film: 27, ISO Speed Ratings: 50](/images/front-page/IMG_20181228_165519-mosque-in-the-market-1500x1200.jpg)
 
 ## 🕌 In search of peace
-I was visiting Al Wakrah Souq in Qatar and it was time to say prayer. 
-There were multiple mosques in the market, and this was one of them - just small, plain and simple.
-Brings peace automagically! 🙏
-
+I was visiting Al Wakrah Souq in Qatar, and it was time to say a prayer.
+There were multiple mosques in the market, and this was one of them - just small, plain, and simple.
+It brings peace automagically! 🙏

--- a/_projects/2019-02-06-frozen-drops.md
+++ b/_projects/2019-02-06-frozen-drops.md
@@ -8,7 +8,7 @@ featured_image: '/images/front-page/IMG_4180-frozen-drops-1600x1100.jpg'
 ![](/images/front-page/IMG_4180-frozen-drops-1600x1100.jpg)
 
 ## Crystal Everywhere
-Freezing rain has caused a rare opportunity to capture frozen drops everywhere. It's simply beautiful.
+Freezing rain created a rare opportunity to capture frozen drops everywhere. It's simply beautiful.
 
 <div class="gallery" data-columns="3">
 	<img src="/images/2019-02/IMG_4262-frozen-drops-on-tree-1700x1100.jpg">

--- a/_projects/2019-05-31-up-close-with-nature.md
+++ b/_projects/2019-05-31-up-close-with-nature.md
@@ -9,11 +9,10 @@ featured_image: '/images/front-page/IMG_5087-nature-up-close-1600x1100.jpg'
 ![](/images/front-page/IMG_5087-nature-up-close-1600x1100.jpg)
 
 ## Up close with nature
-Had a little bit fun with the macro lens. Some of the snaps turned out great.
+I had a little bit of fun with the macro lens. Some of the snaps turned out great.
 
 > "Gazing into the heart of the flower through a macro lens unravels a secret world of intricate patterns, delicate textures, and the subtle beauty that nature intricately weaves in every petal and filament." 
 
 <div class="gallery" data-columns="3">
 	<img src="/images/2019-05/IMG_5325-nature-up-close-dl-1600x1100.jpg">
 </div>
-

--- a/_projects/2020-01-22-wonders-of-the-world.md
+++ b/_projects/2020-01-22-wonders-of-the-world.md
@@ -9,8 +9,8 @@ featured_image: '/images/front-page/IMG_20200120_093033_MP-machu-picchu-1600x110
 ![](/images/2020-01/IMG_20200120_094038-PANO-machu-picchu-1600x1000.jpg)
 
 ## Machu Picchu
-During my recent visit to Peru I visited Machu Picchu. It really was a breathtaking place to be.
-The Inca Civilization's use of stone in high up in the mountain is really mesmerizing.
+During my recent visit to Peru, I visited Machu Picchu. It really was a breathtaking place to be.
+The Inca civilization's use of stone high up in the mountains is truly mesmerizing.
  
 
 <div class="gallery" data-columns="2">

--- a/_projects/2020-09-29-trees-on-fire.md
+++ b/_projects/2020-09-29-trees-on-fire.md
@@ -9,6 +9,6 @@ featured_image: '/images/front-page/IMG_0794-HDR-arrowhead-park-fall-tree-1700x1
 ![](/images/front-page/IMG_0794-HDR-arrowhead-park-fall-tree-1700x1300.jpeg)
 
 ## Fall colors at Arrowhead Park
-Nature does not stop even in pandemic. It was a stunning view at the Arrowhead Provincial Park.
+Nature does not stop, even in a pandemic. It was a stunning view at the Arrowhead Provincial Park.
 
 > "Autumn is a second spring when every leaf is a flower." - Albert Camus

--- a/_projects/2020-10-17-badlands.md
+++ b/_projects/2020-10-17-badlands.md
@@ -9,15 +9,12 @@ featured_image: '/images/front-page/PXL_20201017_221145631-badlands-1600x1200.jp
 ![](/images/front-page/PXL_20201017_221145631-badlands-1600x1200.jpg)
 
 ## Cheltenham Badlands
-A quick visit to Cheltenham Badlands in Caledon at the end of fall season. The view was stunning when the sun was setting.
+A quick visit to the Cheltenham Badlands in Caledon towards the end of the fall season. The view was stunning when the sun was setting.
 
 <div class="image-wrap">
     <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1440.4670397959803!2d-79.944597!3d43.7742272!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x882b0fb7aa0ea18b%3A0x9acd23e488949b0e!2sCheltenham%20Badlands!5e0!3m2!1sen!2sca!4v1609012805061!5m2!1sen!2sca" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
 </div>
 
 
-#### What is Badlands?
+#### What are Badlands?
 > Badlands are a type of dry terrain where softer sedimentary rocks and clay-rich soils have been extensively eroded by wind and water.
-
-
-

--- a/_projects/2021-05-09-spring-is-here-2021.md
+++ b/_projects/2021-05-09-spring-is-here-2021.md
@@ -8,6 +8,6 @@ featured_image: '/images/front-page/IMG_3791-spring-is-here-2021-1200x1800.jpg'
 ![](/images/front-page/IMG_3791-spring-is-here-2021-1200x1800.jpg)
 
 ## Spring is calling
-It's been over a year of pandemic and nature continues to flourish! Sprint of 2021 is here with color and breath of fresh air.
+It's been over a year of the pandemic, and nature continues to flourish! Spring of 2021 is here with color and a breath of fresh air.
 
 > "No winter lasts forever; no spring skips its turn." - Hal Borland

--- a/_projects/2021-05-09-tulip-yellow-blend.md
+++ b/_projects/2021-05-09-tulip-yellow-blend.md
@@ -9,4 +9,4 @@ featured_image: '/images/front-page/IMG_3754-yellow-blend-tulip-1600x1100.jpg'
 ![](/images/front-page/IMG_3754-yellow-blend-tulip-1600x1100.jpg)
 
 ## It's yellow! 🌷
-Love how the yellow tulip blends with green! Only of my favorite color.
+I love how the yellow tulip blends with green! One of my favorite colors.

--- a/_projects/2023-01-22-end-of-the-road.md
+++ b/_projects/2023-01-22-end-of-the-road.md
@@ -9,6 +9,6 @@ featured_image: '/images/front-page/PXL_20230122_231655985.MOTION-1800x1100.jpg'
 ![](/images/front-page/PXL_20230122_231655985.MOTION-1800x1100.jpg)
 
 ## End of the road ❄️
-Took a walk to end of the road on a snowy night! 🌨️
+I took a walk to the end of the road on a snowy night! 🌨️
 
 > "Remember, the end of the road is not the end of the journey. If you get to the end of your rope, tie a knot and hang on." - Franklin D. Roosevelt

--- a/_projects/2023-04-28-little-things-in-jpn.md
+++ b/_projects/2023-04-28-little-things-in-jpn.md
@@ -9,6 +9,6 @@ featured_image: '/images/front-page/PXL_20230428_020422703-mini-shrine-1600x1100
 ![](/images/front-page/PXL_20230428_020422703-mini-shrine.jpg)
 
 ## Little things ⛩️
-A few little shrines in the middle of Fushimi Inari path. Sometimes it's worth stopping for little things.
+A few little shrines in the middle of the Fushimi Inari path. Sometimes it's worth stopping for the little things.
 
 > "Appreciate every little beautiful moment in every day of your life. Give it a try, and you'll see the world from another perspective." - Thea Kristine May

--- a/_projects/2023-10-20-back-to-life.md
+++ b/_projects/2023-10-20-back-to-life.md
@@ -9,7 +9,7 @@ featured_image: '/images/front-page/PXL_20231020_220551135-1000x1500.jpg'
 ![](/images/front-page/PXL_20231020_220551135-back-to-life.jpg)
 
 ## Back to life 🌳
-A road trip to the big basin redwood state park, California. The park is home to the largest continuous stand of ancient coast redwoods south of San Francisco. 
+A road trip to the Big Basin Redwoods State Park, California. The park is home to the largest continuous stand of ancient coast redwoods south of San Francisco.
 These trees are among the tallest and oldest living things on Earth.
 
 The trees were damaged by the 2020 CZU Lightning Complex fire. The fire burned 86,509 acres (35,000 ha) and destroyed 1,490 structures, including 925 homes.

--- a/_projects/2024-02-03-misty-overview.md
+++ b/_projects/2024-02-03-misty-overview.md
@@ -9,6 +9,6 @@ featured_image: '/images/front-page/PXL_20240203_013203498-misty-overview-1600x1
 ![](/images/front-page/PXL_20240203_013203498-misty-overview.jpg)
 
 ## Misty overlook 🏔️
-A snap taken on the way to the Yosemite Valley, California, USA. The valley is known for its stunning waterfalls, giant sequoias, and the iconic El Capitan and Half Dome granite cliffs.
+A snap taken on the way to Yosemite Valley, California, USA. The valley is known for its stunning waterfalls, giant sequoias, and the iconic El Capitan and Half Dome granite cliffs.
 
 > "It is by far the grandest of all the special temples of Nature I was ever permitted to enter." - John Muir

--- a/_projects/2024-02-03-tunnel-view-edge.md
+++ b/_projects/2024-02-03-tunnel-view-edge.md
@@ -9,7 +9,7 @@ featured_image: '/images/front-page/PXL_20240203_204545548-tunnel-view-edge-1400
 ![](/images/front-page/PXL_20240203_204545548-tunnel-view-edge.jpg)
 
 ## Tunnel View Edge 🪨
-Another snap from the Tunnel View vista point at the Yosemite Valley, California, USA.
+Another snap from the Tunnel View vista point at Yosemite Valley, California, USA.
 
 > "Yosemite Valley, to me, is always a sunrise, a glitter of green and golden wonder in a vast edifice of stone and space." - Ansel Adams
 

--- a/_projects/2024-04-23-view-from-fukuoka-tower.md
+++ b/_projects/2024-04-23-view-from-fukuoka-tower.md
@@ -9,9 +9,8 @@ featured_image: '/images/front-page/IMG_2229-fukuoka-shore-edited-1600x1100.jpg'
 ![](/images/front-page/IMG_2229-fukuoka-shore-edited.jpg)
 
 ## Fukuoka Tower 🗼 and Sea Shore 🌊
-Fukuoka, capital of Fukuoka Prefecture, sits on the northern shore of Japan’s Kyushu Island. It’s known for ancient temples, beaches and modern shopping malls, including Canal City.
+Fukuoka, capital of Fukuoka Prefecture, sits on the northern shore of Japan’s Kyushu Island. It’s known for ancient temples, beaches, and modern shopping malls, including Canal City.
 
-📸 Shot is from the Fukuoka Tower facing the sea shore. The tower is 234 meters tall and is the tallest seaside tower in Japan. It was completed in 1989 and has a unique design that resembles a sail.
+📸 The shot is from the Fukuoka Tower, facing the seashore. The tower is 234 meters tall and is the tallest seaside tower in Japan. It was completed in 1989 and has a unique design that resembles a sail.
 
 > "The sea and the horizon – endless, open, and full of possibility."
-

--- a/_projects/2024-04-24-bleeding-sunshine.md
+++ b/_projects/2024-04-24-bleeding-sunshine.md
@@ -9,7 +9,6 @@ featured_image: '/images/front-page/PXL_20240424_083357538-EDIT-bleeding-sun-135
 ![](/images/front-page/PXL_20240424_083357538-EDIT-bleeding-sun.jpg)
 
 ## Bleeding Sun by the Sea 🌊
-The sun was setting down the horizon behind the rock. The sun was bleeding, and the sea was the witness.
+The sun was setting below the horizon behind the rock. The sun was bleeding, and the sea was the witness.
 
 > "At the beach, life is different. Time doesn’t move hour to hour but mood to moment. We live by the currents, plan by the tides, and follow the sun." – Sandy Gingras
-

--- a/_projects/2024-04-24-peeking-through.md
+++ b/_projects/2024-04-24-peeking-through.md
@@ -9,4 +9,4 @@ featured_image: '/images/front-page/PXL_20240424_085014810e-peeking-through-1600
 ![](/images/front-page/PXL_20240424_085014810e-peeking-through.jpg)
 
 ## Peeking through...⛰️
-A unique view of the hole made through the rocks! Hard to capture without true dynamic range.
+A unique view of a hole made through the rocks! It's hard to capture without true dynamic range.


### PR DESCRIPTION
I iterated through all Markdown files in the _posts and _projects directories. I applied corrections for various typos, grammatical mistakes, and punctuation. I ensured front matter remained untouched.
This improves the overall readability and quality of the website content.