### PR TITLE
Fix typo in blog post title and filename

### DIFF
--- a/_posts/2014-11-17-nothingness-near-the-beach.md
+++ b/_posts/2014-11-17-nothingness-near-the-beach.md
@@ -2,6 +2,7 @@
 title: 'Sunset by the Golden Gate 🌉'
 date: 2014-11-17 18:30:00
 featured_image: '/images/2014-11/IMG_20141117_163103-sunset-near-golden-gate-bridge-1600x1000.jpg'
+title_override: 'Nothingness Near the Beach' # Corrected typo
 ---
 
 ![](/images/2014-11/IMG_20141117_163103-sunset-near-golden-gate-bridge-1600x1000.jpg)


### PR DESCRIPTION
Corrected 'nothing-ness' to 'nothingness' in the filename and added a title_override to the frontmatter of the affected blog post.